### PR TITLE
Fix stray Unicode character in results screen

### DIFF
--- a/app/(tabs)/results.tsx
+++ b/app/(tabs)/results.tsx
@@ -1,5 +1,5 @@
 import { Text, View } from 'react-native';
-import { Stack } from 'expo-router'; // ← add this
+import { Stack } from 'expo-router'; 
 import { useLocalSearchParams } from 'expo-router';
 
 export default function Results() {

--- a/components/__tests__/__snapshots__/StyledText-test.js.snap
+++ b/components/__tests__/__snapshots__/StyledText-test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `null`;


### PR DESCRIPTION
## Summary
- remove unicode arrow comment that triggered React Native warning
- update Jest snapshot

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e22bc91c8832fb8605255d02636c3