### PR TITLE
Fix results screen navigation after scan

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, Button, StyleSheet } from 'react-native';
+import { View, Text, Button, StyleSheet, Alert } from 'react-native';
 import { CameraView, useCameraPermissions, BarcodeScanningResult } from 'expo-camera';
+import { useRouter } from 'expo-router';
 
 export default function Scanner() {
   const [permission, requestPermission] = useCameraPermissions();
   const [scanned, setScanned] = useState(false);
+  const router = useRouter();
 
   useEffect(() => {
     requestPermission();
@@ -15,7 +17,13 @@ export default function Scanner() {
 
   const handleBarcodeScanned = ({ type, data }: BarcodeScanningResult) => {
     setScanned(true);
-    alert(`Scanned ${type}: ${data}`);
+    Alert.alert('Scanned', `Scanned ${type}: ${data}`, [
+      {
+        text: 'Results',
+        onPress: () => router.push(`/results?code=${encodeURIComponent(data)}`),
+      },
+      { text: 'Scan again', onPress: () => setScanned(false) },
+    ]);
   };
 
   return (

--- a/app/(tabs)/results.tsx
+++ b/app/(tabs)/results.tsx
@@ -10,7 +10,7 @@ export default function Results() {
 
   return (
     <View style={{ flex: 1, padding: 20 }}>
-      <Text>Scanned code: {code}</Text>
+      <Text>Scanned code: {code ?? 'None'}</Text>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- navigate to the results screen with the scanned barcode
- show placeholder text on the results page if no code provided

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e27e1fbd4832fbb14fc8b3f916123