### PR TITLE
Update API URL handling

### DIFF
--- a/app.json
+++ b/app.json
@@ -38,6 +38,9 @@
       "expo-barcode-scanner",
       "expo-build-properties"
     ],
+    "extra": {
+      "apiUrl": "http://localhost:3000"
+    },
     "experiments": {
       "typedRoutes": true
     }

--- a/app/(tabs)/results.tsx
+++ b/app/(tabs)/results.tsx
@@ -1,6 +1,7 @@
 import { Text, View, StyleSheet, ActivityIndicator } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import { useState, useEffect } from 'react';
+import Constants from 'expo-constants';
 
 type ScrapedItem = {
   url: string;
@@ -19,7 +20,8 @@ export default function Results() {
 
   useEffect(() => {
     if (!code) return;
-    fetch('http://192.168.68.52:3000/scan', {
+    const apiUrl = Constants.expoConfig?.extra?.apiUrl || 'http://localhost:3000';
+    fetch(`${apiUrl}/scan`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ code, user_id: 'some-user-uuid' }), // change for auth


### PR DESCRIPTION
## Summary
- allow configurable backend URL via `extra.apiUrl`
- use `Constants.expoConfig.extra.apiUrl` when fetching results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e38215df8832f8169c2b4dddc0407