### PR TITLE
Add photo confirmation step with OCR

### DIFF
--- a/app/(tabs)/confirm.tsx
+++ b/app/(tabs)/confirm.tsx
@@ -1,0 +1,61 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { View, Text, Button, StyleSheet, Image } from 'react-native';
+import { CameraView, useCameraPermissions } from 'expo-camera';
+import { useLocalSearchParams } from 'expo-router';
+
+export default function Confirm() {
+  const { name = '', size = '' } = useLocalSearchParams<{ name: string; size: string }>();
+  const [permission, requestPermission] = useCameraPermissions();
+  const [photo, setPhoto] = useState<any>(null);
+  const [text, setText] = useState('');
+  const cameraRef = useRef<CameraView>(null);
+
+  useEffect(() => { requestPermission(); }, []);
+
+  const capture = async () => {
+    if (!cameraRef.current) return;
+    const pic = await cameraRef.current.takePictureAsync({ base64: true });
+    setPhoto(pic);
+    try {
+      const res = await fetch('http://192.168.68.52:3000/ocr', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ image: pic.base64 }),
+      });
+      const data = await res.json();
+      setText(data.text || '');
+    } catch (e) {
+      console.log('OCR error', e);
+    }
+  };
+
+  const matchesName = text.toLowerCase().includes(name.toLowerCase());
+  const matchesSize = size ? text.toLowerCase().includes(size.toLowerCase()) : false;
+
+  if (!permission) return <Text>Loading permissions…</Text>;
+  if (!permission.granted) return <Text>No camera access</Text>;
+
+  return (
+    <View style={styles.container}>
+      {photo ? (
+        <Image source={{ uri: photo.uri }} style={styles.preview} />
+      ) : (
+        <CameraView ref={cameraRef} style={styles.camera} />
+      )}
+      {text ? (
+        <View style={styles.results}>
+          <Text>Extracted: {text}</Text>
+          <Text>{matchesName && matchesSize ? 'Product matches' : 'Product mismatch'}</Text>
+        </View>
+      ) : null}
+      <Button title={photo ? 'Retake' : 'Capture'} onPress={() => { photo ? (setPhoto(null), setText('')) : capture(); }} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  camera: { flex: 1 },
+  preview: { flex: 1 },
+  results: { padding: 16 },
+});

--- a/app/(tabs)/results.tsx
+++ b/app/(tabs)/results.tsx
@@ -1,5 +1,5 @@
-import { Text, View, StyleSheet, ActivityIndicator } from 'react-native';
-import { useLocalSearchParams } from 'expo-router';
+import { Text, View, StyleSheet, ActivityIndicator, Button } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useState, useEffect } from 'react';
 
 type ScrapedItem = {
@@ -14,6 +14,7 @@ export const config = { title: 'Scan Results' };
 
 export default function Results() {
   const { code } = useLocalSearchParams<{ code: string }>();
+  const router = useRouter();
   const [loading, setLoading] = useState(true);
   const [items, setItems] = useState<ScrapedItem[]>([]);
 
@@ -64,13 +65,20 @@ export default function Results() {
   return (
     <View style={styles.container}>
       <Text style={styles.heading}>Product: {first.name || 'N/A'}</Text>
-      <Text>Manufacturer: {first.manufacturer || 'N/A'}</Text>
       <Text>Size: {first.size || 'N/A'}</Text>
       {first.sdsUrl ? (
         <Text style={styles.link}>SDS: {first.sdsUrl}</Text>
       ) : (
         <Text>No SDS found</Text>
       )}
+      <Button
+        title="Confirm with Photo"
+        onPress={() =>
+          router.push(
+            `/confirm?code=${encodeURIComponent(code ?? '')}&name=${encodeURIComponent(first.name)}&size=${encodeURIComponent(first.size)}`
+          )
+        }
+      />
     </View>
   );
 }

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
     "express": "^5.1.0",
     "puppeteer": "^24.14.0",
     "puppeteer-extra": "^3.3.6",
-    "puppeteer-extra-plugin-stealth": "^2.11.2"
+    "puppeteer-extra-plugin-stealth": "^2.11.2",
+    "tesseract.js": "^4.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- store only barcode and name for scanned products
- add OCR endpoint using Tesseract
- allow confirming product via photo capture

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f8c5139f8832f8bf02e635468fafd