### PR TITLE
Update README workflow and env example

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,2 @@
+SB_URL=https://your-project.supabase.co
+SB_SERVICE_KEY=your-service-role-key


### PR DESCRIPTION
## Summary
- document Bing-based search, headless scraping, and confirmation flow
- add example environment file for the server

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880b9b9bbcc832f8ee8246c7f0703ef