### PR TITLE
Fix OCR edge case and remove temp files

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -186,10 +186,11 @@ app.post('/ocr', async (req, res) => {
   const { image, cropInfo } = req.body;
   if (!image) return res.status(400).json({ error: 'Missing image' });
 
+  const buffer = Buffer.from(image, 'base64');
+  const filename = `ocr_${Date.now()}.jpg`;
+  fs.writeFileSync(filename, buffer);
+
   try {
-    const buffer = Buffer.from(image, 'base64');
-    const filename = `ocr_${Date.now()}.jpg`;
-    fs.writeFileSync(filename, buffer);
 
     let processed = buffer;
     if (cropInfo && cropInfo.width && cropInfo.height && cropInfo.photoWidth && cropInfo.photoHeight) {
@@ -272,6 +273,8 @@ app.post('/ocr', async (req, res) => {
   } catch (e) {
     console.log('[OCR] Error during OCR:', e);
     res.status(500).json({ error: e.message });
+  } finally {
+    fs.unlink(filename, () => {});
   }
 });
 app.listen(3000, () => console.log('Listening on 3000'));


### PR DESCRIPTION
## Summary
- handle empty image threshold data so deskew doesn't crash
- delete temporary files in OCR endpoint

## Testing
- `python3 -m py_compile ocr_service.py`
- `node --check server/index.js`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688198e2ba4c832f8a6485b61281d8c6