### PR TITLE
Fix manual confirm saving

### DIFF
--- a/app/(tabs)/confirm.tsx
+++ b/app/(tabs)/confirm.tsx
@@ -92,7 +92,17 @@ export default function Confirm() {
   };
 
 
-  const onConfirm = (finalName: string, finalSize: string) => {
+  const onConfirm = async (finalName: string, finalSize: string) => {
+    try {
+      await fetch('http://192.168.68.52:3000/confirm', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code, name: finalName, size: finalSize }),
+      });
+    } catch (e) {
+      console.error('Save error', e);
+    }
+
     Alert.alert(
       'Saved',
       `Name: ${finalName}\nSize: ${finalSize}`,

--- a/server/index.js
+++ b/server/index.js
@@ -277,5 +277,20 @@ app.post('/ocr', async (req, res) => {
     fs.unlink(filename, () => {});
   }
 });
+
+// --- CONFIRM ENDPOINT ---
+app.post('/confirm', async (req, res) => {
+  const { code, name = '', size = '' } = req.body || {};
+  if (!code) return res.status(400).json({ error: 'Missing code' });
+  const updates = { product_name: name, size };
+  const { data, error } = await supabase
+    .from('products')
+    .update(updates)
+    .eq('barcode', code)
+    .select()
+    .maybeSingle();
+  if (error) return res.status(500).json({ error: error.message });
+  res.json({ success: true, product: data });
+});
 app.listen(3000, () => console.log('Listening on 3000'));
 console.log('Supabase:', process.env.SB_URL, 'ServiceRole?', isServiceRole(process.env.SB_SERVICE_KEY));


### PR DESCRIPTION
## Summary
- allow manual confirmation text to be saved
- add backend endpoint to store final name and size

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68819a479ed4832fab6c566840249d72