### PR TITLE
Fix PaddleOCR usage in OCR service

### DIFF
--- a/ocr_service.py
+++ b/ocr_service.py
@@ -56,7 +56,11 @@ def ocr():
 
     try:
         print("Running OCR...")
-        result = ocr_model.ocr(processed, cls=True)
+        try:
+            result = ocr_model.ocr(processed, cls=True)
+        except TypeError:
+            # For newer PaddleOCR versions where `cls` is unsupported
+            result = ocr_model.ocr(processed)
         print("OCR complete.")
         print("PaddleOCR result:", result)
     except Exception as e:


### PR DESCRIPTION
## Summary
- handle PaddleOCR API change in `ocr_service.py`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881e359d940832f8c32066d1bdea48b