### PR TITLE
Fix OCR box iterability issue

### DIFF
--- a/ocr_service.py
+++ b/ocr_service.py
@@ -113,7 +113,8 @@ def ocr():
                 entry = {
                     'text': txt,
                     'confidence': float(conf),
-                    'box': [list(map(float, pt)) for pt in box],
+                    # Flatten and reshape to pairs to avoid iterable errors
+                    'box': np.asarray(box, dtype=float).reshape(-1, 2).tolist(),
                     'area': area
                 }
                 lines.append(entry)
@@ -130,7 +131,8 @@ def ocr():
                 entry = {
                     'text': txt,
                     'confidence': float(conf),
-                    'box': [list(map(float, pt)) for pt in box],
+                    # Flatten and reshape to pairs to avoid iterable errors
+                    'box': np.asarray(box, dtype=float).reshape(-1, 2).tolist(),
                     'area': area
                 }
                 lines.append(entry)


### PR DESCRIPTION
## Summary
- avoid iterating numpy.int16 in `ocr_service.py`
- reshape OCR boxes to coordinate pairs before serialization

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881f6f48434832fb2ee275e8ba223ac