### PR TITLE
Enable backend scripts from project root

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -84,7 +84,7 @@ All colors meet WCAG 2.1 AA contrast requirements. Defined in [`apps/mobile/src/
    ```
 4. **Run the backend**
    ```bash
-   npm start
+   node server/node/index.js
    ```
 5. **Start the OCR service**
    ```bash

--- a/server/node/index.js
+++ b/server/node/index.js
@@ -15,11 +15,11 @@ pptr.use(StealthPlugin());
 import { createClient } from '@supabase/supabase-js';
 import { load } from 'cheerio';
 
-dotenv.config();
-const app = express();
-const supabase = createClient(process.env.SB_URL, process.env.SB_SERVICE_KEY);
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+dotenv.config({ path: path.join(__dirname, '.env') });
+const app = express();
+const supabase = createClient(process.env.SB_URL, process.env.SB_SERVICE_KEY);
 
 let browserPromise;
 async function getBrowser() {
@@ -188,7 +188,8 @@ app.post('/ocr', async (req, res) => {
 
   const buffer = Buffer.from(image, 'base64');
   const filename = `ocr_${Date.now()}.jpg`;
-  fs.writeFileSync(filename, buffer);
+  const filePath = path.join(__dirname, filename);
+  fs.writeFileSync(filePath, buffer);
 
   try {
 
@@ -241,7 +242,10 @@ app.post('/ocr', async (req, res) => {
         .resize({ width: 1200, withoutEnlargement: true })
         .toBuffer();
 
-      fs.writeFileSync(`preprocessed_${Date.now()}.jpg`, processed);
+      fs.writeFileSync(
+        path.join(__dirname, `preprocessed_${Date.now()}.jpg`),
+        processed
+      );
     } else {
       processed = await sharp(buffer)
         .rotate()
@@ -251,7 +255,10 @@ app.post('/ocr', async (req, res) => {
         .sharpen()
         .resize({ width: 1200, withoutEnlargement: true })
         .toBuffer();
-      fs.writeFileSync(`preprocessed_${Date.now()}.jpg`, processed);
+      fs.writeFileSync(
+        path.join(__dirname, `preprocessed_${Date.now()}.jpg`),
+        processed
+      );
     }
 
     // ---- Send processed image to Python microservice! ----
@@ -274,7 +281,7 @@ app.post('/ocr', async (req, res) => {
     console.log('[OCR] Error during OCR:', e);
     res.status(500).json({ error: e.message });
   } finally {
-    fs.unlink(filename, () => {});
+    fs.unlink(filePath, () => {});
   }
 });
 


### PR DESCRIPTION
## Summary
- allow `server/node/index.js` to load `.env` when started from repo root
- generate output images relative to the script directory
- document running the backend from repo root

## Testing
- `npm install`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68849135f234832f8f9cb843d0caec2b